### PR TITLE
Optimize images

### DIFF
--- a/src/components/Secrets.vue
+++ b/src/components/Secrets.vue
@@ -40,6 +40,9 @@ export default {
 
 <style scoped>
 img{
+  width: 50px;
+  object-fit: cover;
+  object-position: center top;
   height: 50px;
   padding: 5px;
 }


### PR DESCRIPTION
This makes two little improvements to how the images are loaded:
* loads all images in one request to wdqs instead of making one request per image (0db99d5)
* loads 100px thumbnails instead of full-size images (which can be very large) (c34e871)